### PR TITLE
Add height and width to Video ctor

### DIFF
--- a/sAS3Cam.as
+++ b/sAS3Cam.as
@@ -88,7 +88,7 @@ package {
             var doSmoothing:Boolean = this.loaderInfo.parameters["smoothing"];
             var doDeblocking:Number = this.loaderInfo.parameters["deblocking"];
 
-            video = new Video();
+            video = new Video(camResolution[0],camResolution[1]);
             video.smoothing  = doSmoothing;
             video.deblocking = doDeblocking;
             video.attachCamera(useCamera);


### PR DESCRIPTION
Fixes the Video sizing so that it actually respects the values set in the JS instead of defaulting to the 320,240 size. 
